### PR TITLE
Configure Vite for GitHub Pages deployment

### DIFF
--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,1 +1,0 @@
-# placeholder for Pages. Will be replaced by build output.

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,3 @@
+<!doctype html><meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/zero-day-of-water/">
+<script>location.replace('/zero-day-of-water/');</script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "18.2.0",

--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,19 +3,21 @@ import react from '@vitejs/plugin-react';
 import { viteSingleFile } from 'vite-plugin-singlefile';
 
 export default defineConfig({
-  base: "",
+  base: '/zero-day-of-water/',
+  root: 'src',
   plugins: [
     react(),
-    viteSingleFile()
+    viteSingleFile(),
   ],
   build: {
-    outDir: "docs",
+    outDir: '../docs',
+    emptyOutDir: true,
     assetsInlineLimit: 100000000,
     cssCodeSplit: false,
     rollupOptions: {
       output: {
-        manualChunks: undefined
-      }
-    }
-  }
+        manualChunks: undefined,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- set Vite's base to `/zero-day-of-water/` and build from `src` into `docs`
- standardize npm preview script
- add GitHub Pages helpers: `404.html` redirect and `.nojekyll`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68957b1949b4832887a07641ae92a79f