### PR TITLE
افزودن آیکون و چیدمان فارسی

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import './styles/global.css';
 import { formatDateJalali } from './utils/locale.js';
 import KpiCard from './components/KpiCard.jsx';
 import ProjectList from './components/ProjectList.jsx';
+import Droplet from './components/icons/Droplet.jsx';
+import PeopleRow from './components/icons/PeopleRow.jsx';
 import { kpis, projects } from './data/sample.js';
 
 export default function App(){
@@ -10,8 +12,20 @@ export default function App(){
     <div className="container">
       <div className="grid3">
         <KpiCard title="شهر" value={kpis.city.value} trend={kpis.city.trend} subtitle={kpis.city.subtitle} />
-        <KpiCard title="سدها" value={kpis.dams.value} trend={kpis.dams.trend} subtitle={kpis.dams.subtitle} />
-        <KpiCard title="شهروندان" value={kpis.residents.value} trend={kpis.residents.trend} subtitle={kpis.residents.subtitle} />
+        <KpiCard
+          title="سدها"
+          value={kpis.dams.value}
+          trend={kpis.dams.trend}
+          subtitle={kpis.dams.subtitle}
+          icon={<Droplet label="درصد پرشدگی سدها" />}
+        />
+        <KpiCard
+          title="شهروندان"
+          value={kpis.residents.value}
+          trend={kpis.residents.trend}
+          subtitle={kpis.residents.subtitle}
+          icon={<PeopleRow label="درصد شهروندان کم‌مصرف" />}
+        />
       </div>
 
       <div className="hero card">

--- a/src/components/KpiCard.jsx
+++ b/src/components/KpiCard.jsx
@@ -1,15 +1,20 @@
+import { cloneElement } from 'react';
 import { formatPercent } from '../utils/locale.js';
 
-export default function KpiCard({ title, value, trend=null, subtitle=null }) {
+export default function KpiCard({ title, value, trend=null, subtitle=null, icon=null }) {
   const isDown = typeof trend === 'number' && trend < 0;
   const t = isDown ? 'down' : 'up';
   const arrow = isDown ? '▼' : '▲';
+  const label = title;
+  const aLabel = `${title}: ${formatPercent(value)}`;
 
   return (
     <div className="card">
       <h3 className="kpi-title">{title}</h3>
       <div className="kpi-wrap">
-        <div className="donut" style={{ '--p': value }} />
+        {icon ? cloneElement(icon, { percent: value, label: icon.props.label || label }) : (
+          <div className="donut" style={{ '--p': value }} role="img" aria-label={aLabel} />
+        )}
         <div>
           <p className="kpi-value">{formatPercent(value)}</p>
           {subtitle && <div className="kpi-sub">{subtitle}</div>}

--- a/src/components/icons/Droplet.jsx
+++ b/src/components/icons/Droplet.jsx
@@ -1,0 +1,36 @@
+import { useId } from 'react';
+import { formatPercent } from '../../utils/locale.js';
+
+export default function Droplet({ percent=0, size=64, label='' }) {
+  const id = useId();
+  const p = Math.max(0, Math.min(100, percent));
+  const h = 160; // height of viewBox
+  const viewW = 120;
+  const fillY = h - (h * p) / 100;
+  const maskId = `dropMask-${id}`;
+  const outerPath = 'M60 5C42 35 20 80 20 110a40 40 0 0 0 80 0c0-30-22-75-40-105Z';
+
+  return (
+    <svg
+      viewBox="0 0 120 160"
+      width={size}
+      height={(size * 160) / 120}
+      role="img"
+      aria-label={`${label}: ${formatPercent(p)}`}
+    >
+      <defs>
+        <mask id={maskId}>
+          <path d={outerPath} fill="#fff" />
+          <rect x="0" y="0" width={viewW} height={fillY} fill="#000">
+            <animate attributeName="height" from={h} to={fillY} dur="0.8s" fill="freeze" />
+          </rect>
+        </mask>
+      </defs>
+      <path d={outerPath} fill="#e0f2fe" stroke="#0ea5e9" strokeWidth="4" />
+      <rect x="0" y="0" width={viewW} height={h} fill="#0ea5e9" mask={`url(#${maskId})`} />
+      <path d={outerPath} fill="none" stroke="#0ea5e9" strokeWidth="4" />
+      <path d={outerPath} fill="#fff" transform="translate(26 30) scale(0.55)" />
+    </svg>
+  );
+}
+

--- a/src/components/icons/PeopleRow.jsx
+++ b/src/components/icons/PeopleRow.jsx
@@ -1,0 +1,30 @@
+import { formatPercent } from '../../utils/locale.js';
+
+export default function PeopleRow({ percent=0, count=10, size=24, label='' }) {
+  const p = Math.max(0, Math.min(100, percent));
+  const filled = Math.round((p / 100) * count);
+  const width = count * 12;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} 24`}
+      width={width}
+      height={size}
+      role="img"
+      aria-label={`${label}: ${formatPercent(p)}`}
+    >
+      {Array.from({ length: count }).map((_, i) => {
+        const idx = count - 1 - i;
+        const color = i < filled ? '#334155' : '#d1d5db';
+        return (
+          <g key={i} transform={`translate(${idx * 12} 0)`} fill={color}>
+            <circle cx="6" cy="4" r="4" />
+            <rect x="4" y="8" width="4" height="8" rx="2" />
+            <rect x="2" y="16" width="8" height="8" rx="2" />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,7 +1,7 @@
 @import './tokens.css';
 *{box-sizing:border-box}
 html,body,#root{height:100%}
-body{margin:0;font-family:Vazirmatn,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sans Arabic","IRANSans",Arial,sans-serif;background:var(--bg);color:var(--ink)}
+body{margin:0;font-family:Vazirmatn,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sans Arabic","IRANSans",Arial,sans-serif;background:var(--bg);color:var(--ink);direction:rtl;text-align:right}
 .container{max-width:1100px;margin:0 auto;padding:var(--space-8) var(--space-3)}
 .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-3)}
 .card{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:var(--space-6)}
@@ -26,6 +26,6 @@ body{margin:0;font-family:Vazirmatn,system-ui,-apple-system,Segoe UI,Roboto,"Not
 .state{font-size:var(--mono)}
 .state.ok{color:var(--success)} .state.warn{color:var(--warning)} .state.bad{color:var(--danger)}
 .legend{display:flex;gap:1rem;margin-top:.5rem;color:var(--muted);font-size:var(--mono)}
-.legend i{display:inline-block;width:10px;height:10px;border-radius:2px;margin-left:.35rem}
+.legend i{display:inline-block;width:10px;height:10px;border-radius:2px;margin-inline-start:.35rem}
 .legend .ok i{background:var(--success)} .legend .warn i{background:var(--warning)} .legend .bad i{background:var(--danger)}
 @media (max-width:900px){.grid3{grid-template-columns:1fr}.kpi-wrap{justify-content:space-between}}


### PR DESCRIPTION
## خلاصه
- ساخت آیکون قطره با پرشدگی پویا و توضیحات دسترس‌پذیری
- افزودن آیکون ردیف آدمک‌ها برای نمایش درصد شهروندان
- پشتیبانی از جهت راست‌به‌چپ و متن فارسی در کارت‌های KPI

## آزمون‌ها
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689583cd02c08328a187b45aa8ba8d91