### PR TITLE
feat: add source stamp for reservoir and KPI cards

### DIFF
--- a/docs/data/reservoirs.json
+++ b/docs/data/reservoirs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "doosti",
+    "nameFa": "سد دوستی",
+    "capacityMm3": 1250,
+    "deadStorageMm3": 150,
+    "volumeNowMm3": 69,
+    "lastUpdate": "2025-08-02T12:00:00Z",
+    "source": { "name": "گزارش رسمی وزارت نیرو", "url": "https://..." }
+  },
+  {
+    "id": "torogh",
+    "nameFa": "سد طرق",
+    "capacityMm3": 32.8,
+    "deadStorageMm3": 4.5,
+    "volumeNowMm3": 2.6,
+    "lastUpdate": "2025-08-02T12:00:00Z",
+    "source": { "name": "آب منطقه‌ای خراسان", "url": "https://..." }
+  }
+]

--- a/docs/src/components/KPICard.tsx
+++ b/docs/src/components/KPICard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import SourceStamp from './SourceStamp';
+import { formatFaNumber } from '../utils/format';
+
+interface SourceInfo {
+  name: string;
+  url?: string;
+}
+
+interface Meta {
+  source: SourceInfo;
+  lastUpdate: string;
+}
+
+interface Props {
+  title: string;
+  value: number;
+  meta?: Meta;
+}
+
+export default function KPICard({ title, value, meta }: Props) {
+  return (
+    <div className="relative border rounded p-4">
+      {meta && (
+        <div className="absolute top-2 right-2">
+          <SourceStamp source={meta.source} lastUpdate={meta.lastUpdate} />
+        </div>
+      )}
+      <h3 className="text-sm font-medium">{title}</h3>
+      <p className="text-2xl mt-2">{formatFaNumber(value)}٪</p>
+    </div>
+  );
+}

--- a/docs/src/components/ReservoirCard.tsx
+++ b/docs/src/components/ReservoirCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import SourceStamp from './SourceStamp';
+import { formatFaNumber, formatMm3 } from '../utils/format';
+import reservoirs from '../../data/reservoirs.json';
+
+interface Reservoir {
+  id: string;
+  nameFa: string;
+  capacityMm3: number;
+  deadStorageMm3: number;
+  volumeNowMm3: number;
+  lastUpdate: string;
+  source: { name: string; url?: string };
+}
+
+const data = reservoirs as Reservoir[];
+
+interface Props {
+  id: string;
+}
+
+export default function ReservoirCard({ id }: Props) {
+  const reservoir = data.find((r) => r.id === id);
+  if (!reservoir) return null;
+
+  const percent = (reservoir.volumeNowMm3 / reservoir.capacityMm3) * 100;
+
+  return (
+    <div className="border rounded p-4">
+      <h3 className="text-base font-medium">{reservoir.nameFa}</h3>
+      <SourceStamp source={reservoir.source} lastUpdate={reservoir.lastUpdate} className="mt-1" />
+      <div className="mt-2 space-y-1 text-sm">
+        <p>حجم فعلی: {formatMm3(reservoir.volumeNowMm3)}</p>
+        <p>درصد پرشدگی: {formatFaNumber(+percent.toFixed(1))}٪</p>
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/SourceStamp.tsx
+++ b/docs/src/components/SourceStamp.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface SourceInfo {
+  name: string;
+  url?: string;
+}
+
+interface SourceStampProps {
+  source: SourceInfo;
+  lastUpdate: string;
+  className?: string;
+}
+
+export default function SourceStamp({ source, lastUpdate, className = '' }: SourceStampProps) {
+  const date = new Intl.DateTimeFormat('fa-IR-u-ca-persian', {
+    dateStyle: 'long',
+  }).format(new Date(lastUpdate));
+
+  return (
+    <div className={`text-xs text-gray-500 flex flex-col space-y-0.5 ${className}`}>
+      <span>
+        منبع:
+        {source.url ? (
+          <a href={source.url} target="_blank" rel="noopener noreferrer" className="underline ml-1">
+            {source.name}
+          </a>
+        ) : (
+          <span className="ml-1">{source.name}</span>
+        )}
+      </span>
+      <span>آخرین به‌روزرسانی: {date}</span>
+    </div>
+  );
+}

--- a/docs/src/utils/format.ts
+++ b/docs/src/utils/format.ts
@@ -1,0 +1,5 @@
+export const formatFaNumber = (n: number): string =>
+  new Intl.NumberFormat('fa-IR').format(n);
+
+export const formatMm3 = (n: number): string =>
+  `${formatFaNumber(n)} میلیون مترمکعب`;


### PR DESCRIPTION
## Summary
- add reservoirs dataset with source and timestamps
- implement SourceStamp component and Persian number utilities
- show source stamp on ReservoirCard and KPICard

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689626c5cf7c8328b2baea875f0f31e9